### PR TITLE
Fix multiple H1 headers in Distributed Agent Runtime documentation

### DIFF
--- a/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/distributed-agent-runtime.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/core-user-guide/framework/distributed-agent-runtime.ipynb
@@ -189,16 +189,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Cross-Language Runtimes\n",
+    "## Cross-Language Runtimes\n",
     "The process described above is largely the same, however all message types MUST use shared protobuf schemas for all cross-agent message types.\n",
     "\n",
-    "# Next Steps\n",
+    "## Next Steps\n",
     "To see complete examples of using distributed runtime, please take a look at the following samples:\n",
     "\n",
     "- [Distributed Workers](https://github.com/microsoft/autogen/tree/main/python/samples/core_grpc_worker_runtime)  \n",
     "- [Distributed Semantic Router](https://github.com/microsoft/autogen/tree/main/python/samples/core_semantic_router)  \n",
     "- [Distributed Group Chat](https://github.com/microsoft/autogen/tree/main/python/samples/core_distributed-group-chat)  \n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://microsoft.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes the issue of multiple `<h1>` headers in the Distributed Agent Runtime documentation page. The page has more than one `<h1>` which violates semantic HTML structure. This fix downgrades the inner section headings (e.g., "Cross-Language Runtimes", "Next Steps") to `<h2>`.

## Related issue number

Related issue: [#6090](https://github.com/microsoft/autogen/issues/6090)

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
